### PR TITLE
Fix markdown syntax, minor edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ the UART cable (which I failed at)
 - ADB
 - USB Reverse Tethering/RNDIS (guest)
 - USB OTG (host)
-- fb0
+- Framebuffer
 - Audio - you need to setup PulseAudio as systemwide. Not sure why it does not work as a normal user. You will also need the alsaucm files from libasound2-data_1.0.27.2-1ubuntu6_all.deb
 
 ### Bugs/What's not working
@@ -31,7 +31,8 @@ kgsl_bo_gpuaddr comes back a 0
 
 - NFC (if you know how to test it please let @Davideddu know, I have a bunch of NFC tags to test it with. You can tag me in an issue).
 
-## Quick guide (boot with fastboot)
+# Setup guides
+## Basic setup and booting with fastboot
 
 1. Follow the instuctions at https://github.com/borh/nexus-7-2013-arch-scripts to get a working chroot.
 1. Remove trimslice packages from chroot.
@@ -39,95 +40,112 @@ kgsl_bo_gpuaddr comes back a 0
 1. Build the kernel (instructions below).
 1. Build the initramfs (instructions below).
 1. Edit makebootimage.sh to point to the new kernel and to the initramfs you just built and run it to create an Android boot image.
-1. Use *fastboot boot <image\>* to boot the image you just created.
+1. Use ```fastboot boot <image>``` to boot the image you just created.
 1. Enjoy ;)
 
 ## Booting with MultiROM (using an image)
 
 You will need to follow the guide at http://forum.xda-developers.com/showthread.php?t=2457063 to install MultiROM on your device.
 
+Also follow the basic guide above to create the chroot, then follow the following steps.
+
 The init script needs to be modified to support this. You currently can't boot the same boot image via both fastboot and MultiROM.
 
-1. Create a ROM folder for ArchLinuxARM.
-	adb shell mkdir /data/media/0/multirom/roms/*<rom name\>*
-1. Restart adbd as root using *adb root*; if your ROM doesn't support it, reboot to recovery.
-1. Push the provided rom_info.txt file. You might want to edit it, it's a plaintext config file documented at https://github.com/Tasssadar/multirom/wiki/Add-support-for-new-ROM-type
-	adb push rom_info.txt /data/media/0/multirom/roms/*<rom name\>*/
-1. Move your root image to /data/media/0/multirom/roms/ArchLinux*<rom name\>*/root.img
-1. Edit the init script (systemd-initramfs/init) to point to your new root.img location, then rebuild the initramfs (you don't need to build the boot image for MultiROM).
-1. Make sure you have the kernel zImage in
-/data/media/0/multirom/roms/*<rom name\>*/boot/vmlinuz
-and the initramfs in
-/data/media/0/multirom/roms/*<rom name\>*/boot/initrd.img
-1. Mount the image, and copy these files (with the same names) to /boot/ into it.
+1. Create a ROM folder for Arch Linux
+    
+    ```adb shell mkdir /data/media/0/multirom/roms/<rom name>```
+2. Restart adbd as root using ```adb root```; if your ROM doesn't support it, reboot to recovery.
+3. Push the provided rom_info.txt file. You might want to edit it, it's a plaintext config file documented at https://github.com/Tasssadar/multirom/wiki/Add-support-for-new-ROM-type
+    
+    ```adb push rom_info.txt /data/media/0/multirom/roms/*\<rom name\>*/```
+4. Move your root image to ```/data/media/0/multirom/roms/<rom name>/root.img````
+5. Edit the init script (systemd-initramfs/init) to point to your new root.img location, then rebuild the initramfs (you don't need to build the boot image for MultiROM).
+6. Make sure you have the kernel zImage in ```/data/media/0/multirom/roms/<rom name>/boot/vmlinuz``` and the initramfs in ```/data/media/0/multirom/roms/<rom name>/boot/initrd.img```
+7. Mount the image, and copy these files (with the same names) to /boot/ into it.
 
 ## Booting with MultiROM (directly from /data, no image)
 
 *(coming soon)*
 
 ## Booting from USB with MultiROM (not tested)
-You basically have to follow the MultiROM image steps, but instead of placing the files into /data/media/0/multirom you will want to put them into a *multirom* directory inside of your fat32-formatted USB drive. You will however have to edit the init script, find the USB drive's device (it should be /dev/block/sda1 but don't count on that), mount it and pass the torch to systemd's init.
+You basically have to follow the MultiROM image booting steps, but instead of placing the files into /data/media/0/multirom you will want to put them into a ```multirom``` directory inside of your fat32-formatted USB drive. You will however have to edit the init script, find the USB drive's device (it should be /dev/block/sda1 but don't count on that), mount it and pass the torch to systemd's init.
 
 This hasn't been tested yet. Detailed instructions will come as soon as I test it.
 
 ## Getting Wi-Fi working
 
-A normal Nexus 7 Flo boot will call */system/bin/conn_init*, which does a whole lot of verifying your MAC address and then writes out a config with the MAC address in it. Very annoying (especially if you want to spoof it). To get around this you need a copy of the Wi-Fi configs and manually enable the wifi driver since it's not loaded on boot.
+A normal Nexus 7 Flo boot will call ```/system/bin/conn_init```, which does a whole lot of verifying your MAC address and then writes out a config with the MAC address in it. Very annoying (especially if you want to spoof it). To get around this you need a copy of the Wi-Fi configs and manually enable the wifi driver since it's not loaded on boot.
 
 The firmware.service is only needed since the firmware is not loaded in the initramfs.
 
-1. Copy /system/vendor/firmware [android] to /usr/lib/firmware [arch] (you might want to mount system in the chroot or copy the files to /sdcard, then access them from /media/sdcard in the chroot).
-1. *rm /usr/lib/firmware/wlan/prima/{WCNSS_qcom_cfg.ini,WCNSS_qcom_wlan_nv.bin}* <-- these are simlinks
-1. *cp /data/misc/wifi/{WCNSS_qcom_cfg.ini,WCNSS_qcom_wlan_nv.bin} /usr/lib/firmware/wlan/prima/* <-- these are the files which conn_init writes your mac address to - again, use /sdcard or mount /data into the chroot.
-1. Copy the provided firmware.service to /etc/systemd/system/
-1. *ln -s /etc/systemd/system/firmware.service /etc/systemd/system/multi-user.target.wants/firmware.service*
-1. *ln -s /usr/lib/systemd/system/wpa_supplicant-nl80211@wlan0.service /etc/systemd/system/multi-user.target.wants/wpa_supplicant-nl80211@wlan0.service*
-1. *ln -s /lib/systemd/system/dhcpcd.service /etc/systemd/system/multi-user.target.wants/dhcpcd.service*
-1. *ln -s /lib/systemd/system/sshd.service /etc/systemd/system/multi-user.target.wants/sshd.service*
-1. Disable the wpa_supplicant hook in /etc/dhcpcd.conf by adding *nohook wpa_supplicant* at the end.
+1. Copy ```/system/vendor/firmware``` (android) to ```/usr/lib/firmware``` (arch) (you might want to mount system in the chroot or copy the files to /sdcard, then access them from /media/sdcard in the chroot).
+1. ```rm /usr/lib/firmware/wlan/prima/{WCNSS_qcom_cfg.ini,WCNSS_qcom_wlan_nv.bin}``` ← these are simlinks
+1. ```cp /data/misc/wifi/{WCNSS_qcom_cfg.ini,WCNSS_qcom_wlan_nv.bin} /usr/lib/firmware/wlan/prima/``` ← these are the files which conn_init writes your mac address to - again, use /sdcard or mount /data into the chroot.
+1. Copy the provided ```firmware.service``` to ```/etc/systemd/system/```
+1. ```ln -s /etc/systemd/system/firmware.service /etc/systemd/system/multi-user.target.wants/firmware.service```
+1. ```ln -s /usr/lib/systemd/system/wpa_supplicant-nl80211@wlan0.service /etc/systemd/system/multi-user.target.wants/wpa_supplicant-nl80211@wlan0.service```
+1. ```ln -s /lib/systemd/system/dhcpcd.service /etc/systemd/system/multi-user.target.wants/dhcpcd.service```
+1. ```ln -s /lib/systemd/system/sshd.service /etc/systemd/system/multi-user.target.wants/sshd.service```
+1. Disable the wpa_supplicant hook in ```/etc/dhcpcd.conf``` by adding ```nohook wpa_supplicant``` at the end.
 
 ### Setting up shared Wi-Fi configuration between Arch and Android
 
 1. Make sure /data is mounted at boot:
-	mkdir /data
-	echo '/dev/disk/by-partlabel/userdata /data ext4 errors=remount-ro 0 0' >> /etc/fstab
-	mount /data
-1. Forcibly symlink the Android wpa_supplicant.conf to the Linux location.
-	ln -fs /data/misc/wifi/wpa_supplicant.conf /etc/wpa_supplicant/wpa_supplicant-nl80211-wlan0.conf
+    
+    ```
+    mkdir /data
+    echo '/dev/disk/by-partlabel/userdata /data ext4 errors=remount-ro 0 0' >> /etc/fstab
+    mount /data
+    ```
+2. Forcibly symlink the Android wpa_supplicant.conf to the Linux location.
+    
+    ```
+    ln -fs /data/misc/wifi/wpa_supplicant.conf /etc/wpa_supplicant/wpa_supplicant-nl80211-wlan0.conf
+    ```
 1. Create a name for the Android wifi group
-	groupadd -g $(stat -c '%g' /data/misc/wifi) -r android_wifi
+    
+    ```
+    groupadd -g $(stat -c '%g' /data/misc/wifi) -r android_wifi
+    ```
 1. Add your main user to said group, so you can access the control sockets. You will need to manually their path if you want to edit the Wi-Fi network configuration.
-	usermod -aG android_wifi *<your username\>*
+    
+    ```
+	usermod -aG android_wifi *\<your username\>*
+    ```
 
 ## Getting fbterm console
 
-1. Copy provided fbterm/getty@.service to /etc/systemd/system/
-1. Copy fbterm/fbterm-login to /opt/fbterm-login and make it executable
-1. *systemctl enable getty@tty1.service*
+1. Copy provided ```fbterm/getty@.service``` to ```/etc/systemd/system/```
+1. Copy ```fbterm/fbterm-login``` to ```/opt/fbterm-login``` and make it executable
+1. ```systemctl enable getty@tty1.service```
 
-*ln -s getty@.service autovt@.service* to get it on all vt's
+```ln -s getty@.service autovt@.service``` to get it on all vt's
 
 ## Getting Xorg
 
-Install xf86-video-freedreno-git (AUR). Use the xorg.conf included
+Install [xf86-video-freedreno-git](https://aur.archlinux.org/packages/xf86-video-freedreno-git) (AUR). Use the xorg.conf included
 
 Instead of filling the AUR with crap you can use the mesa and libdrm PKGBUILDs
 included. Always use the git versions as they have the latest freedreno fixes.
 
 ## Refreshing (refresher.c)
 
-Since the MSMFB_SW_REFRESHER does not seem to be working, I wrote this instead.
-Just compile it inside of the chroot (do not crosscompile it on your computer), copy it to /bin/refresher and make it executable.
+Since the ```MSMFB_SW_REFRESHER``` does not seem to be working, I wrote this instead.
+Just compile it inside of the chroot (do not crosscompile it on your computer), copy it to ```/bin/refresher``` and make it executable.
 
 You can use the included systemd unit file for the refresher:
-Copy the provided systemd/refresher.service to /etc/systemd/system/refresher.service
+Copy the provided ```systemd/refresher.service``` to ```/etc/systemd/system/refresher.service```.
 
 ## Serial console
 
-USB serial works. I had some problems connecting with the Android Composite Gadget, however just using the USB_G_SERIAL kernel config seems to work (it's enabled by default in the patched kernel).
+USB serial works. I had some problems connecting with the Android Composite Gadget, however just using the ```USB_G_SERIAL``` kernel config seems to work (it's enabled by default in the patched kernel).
 
 To enable it, run
-	systemctl enable serial-getty@ttyGS0.service
+
+```
+systemctl enable serial-getty@ttyGS0.service
+```
+
 and then you will be able to connect to the device via minicom or similar on /dev/ttyACM0.
 
 Getting kernel console boot messages is still a no go as the device is registered too late to work.
@@ -135,8 +153,10 @@ Getting kernel console boot messages is still a no go as the device is registere
 ## Enabling ADB and RNDIS (reverse USB tethering)
 
 1. Create this link for ADB to be able to find the shell, etc.
-	ln -s / /system
-1. Add the included systemd-tmpfiles config files. They go in /etc/tmpfiles.d, and require a reboot to apply them.
+    ```
+    ln -s / /system
+	```
+1. Add the included systemd-tmpfiles config files. They go in  ```/etc/tmpfiles.d```, and require a reboot to apply them.
 
 ADB shell works, but you will need to set the size ($COLUMNS and $LINES) and terminal type ($TERM) manually. 
 
@@ -144,7 +164,7 @@ To use RNDIS, plug the Nexus into a computer and bridge the virtual ethernet ada
 
 # Kernel
 
-You can use the kernel from here https://github.com/crondog/kernel_msm. Use the **mr1** branch.
+You can use the kernel from here: https://github.com/crondog/kernel_msm. Use the **mr1** branch.
 
 ## Building the kernel
 
@@ -154,7 +174,7 @@ Just make sure you use the patched fork provided above instead of the default re
 
 ## Getting touchscreen working
 
-Apply provided *0001-make-ektf3k-driver-report-non-MT-events-too.patch*.
+Apply provided ```0001-make-ektf3k-driver-report-non-MT-events-too.patch```.
 
 ## Kernel configuration
 I used the following additional configs to get this working. Some might not be
@@ -215,10 +235,10 @@ Make sure *abootimg* is installed.
 
 
 ## Using mkinitcpio
-1. Copy zImage to /boot/
-1. Copy modules to /lib/modules/`uname -r`
-1. Apply mkinitcpio.patch
-1. Copy hooks/imgmount and install/imgmount to /lib/initcpio
-1. sudo mkinitcpio -p linux
-1. abootimg --create boot.img -f bootimg.cfg -k /boot/zImage -r /boot/initramfs-linux.img
+1. Copy ```zImage``` to ```/boot```
+1. Copy modules to ```/lib/modules/`uname -r````
+1. Apply ```mkinitcpio.patch```
+1. Copy ```hooks/imgmount``` and ```install/imgmount``` to ```/lib/initcpio```
+1. ```sudo mkinitcpio -p linux```
+1. ```abootimg --create boot.img -f bootimg.cfg -k /boot/zImage -r /boot/initramfs-linux.img```
 


### PR DESCRIPTION
Ok I fixed the markdown. It's now perfectly visible. I simply used a GitHub-specific markdown feature that allows embedding inline code using triple ```````, the stuff inside of that is not parsed.
I also changed the section structure so that now we have three main sections:
- Setup guides, which contains the installation guides and the guides on how to get stuff working
- Kernel, which contains all the kernel stuff (except the serial console, which I think belongs to the setup guides, as it's pretty important in order to be able to control the newly booted system)
- Initramfs

I should probably split the setup guides into Installation (containing only the first steps to get the chroot and boot it using the different methods) and another section named "Getting stuff working" or something like that where I'll put the wifi, console, etc stuff.
